### PR TITLE
Route /pastes to root path

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
   resources :parses, only: [:create]
   resources :pastes, only: [:show, :create]
+  get '/pastes', to: redirect('/')
 end

--- a/spec/requests/pages_requests_spec.rb
+++ b/spec/requests/pages_requests_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+describe '/pages' do
+  it 'routes the /pages path to the homepage' do
+    get '/pastes'
+
+    expect(response).to redirect_to(root_path)
+  end
+end


### PR DESCRIPTION
When visiting the pastes path, it raised a 404 message. This will redirect users to the root path instead.