### PR TITLE
Don't create duplicated pastes

### DIFF
--- a/app/controllers/pastes_controller.rb
+++ b/app/controllers/pastes_controller.rb
@@ -7,7 +7,7 @@ class PastesController < ApplicationController
   end
 
   def create
-    @paste = Paste.new(paste_params)
+    @paste = Paste.find_or_initialize_by(paste_params)
 
     if @paste.save
       redirect_to @paste

--- a/spec/controllers/pastes_controller_spec.rb
+++ b/spec/controllers/pastes_controller_spec.rb
@@ -52,6 +52,19 @@ describe PastesController do
 
         expect(response).to redirect_to(assigns[:paste])
       end
+
+      context 'with the exact same content as another paste' do
+        it 'redirects to that paste instead of creating it' do
+          paste = create(:paste)
+          duplicate_attrs = { language: paste.language, source: paste.source }
+          paste_count = Paste.count
+
+          post :create, paste: duplicate_attrs
+
+          expect(assigns[:paste]).to eq(paste)
+          expect(Paste.count).to eq(paste_count)
+        end
+      end
     end
 
     context 'invalid attributes' do


### PR DESCRIPTION
A lot of users will click the Save this button without changing
anything from the default code example. This was recreating the same
default paste over and over again. This will first try and find a
duplicate paste and redirect to that. If none exists, then it will
create a new paste.