### PR TITLE
Add humans.txt, fix some old tests

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,6 +7,7 @@
   <title><%= title %></title>
   <%= stylesheet_link_tag :application, media: 'all' %>
   <link href='http://fonts.googleapis.com/css?family=Raleway:800,500|Source+Code+Pro:400,700' rel='stylesheet' type='text/css'>
+  <link rel="author" href="humans.txt" />
   <%= favicon_link_tag %>
   <%= csrf_meta_tags %>
 </head>

--- a/public/humans.txt
+++ b/public/humans.txt
@@ -1,0 +1,11 @@
+# humanstxt.org/
+# The humans responsible & technology colophon
+
+# TEAM
+
+    Edward Loveall -- Designer, Developer -- @edwardloveall
+    Jeanine Adkisson -- Developer (of the website and Rouge gem) -- @jneen_
+
+# TECHNOLOGY COLOPHON
+
+    rails, bourbon, neat

--- a/spec/controllers/pastes_controller_spec.rb
+++ b/spec/controllers/pastes_controller_spec.rb
@@ -18,16 +18,6 @@ describe PastesController do
       expect(assigns[:paste]).to eq(paste)
     end
 
-    it 'assigns a parse to @parse' do
-      paste = create(:paste)
-      parse = double('parse')
-      allow(Highlighter).to receive(:perform).and_return(parse)
-
-      get :show, id: HASHIDS.encode(paste.id)
-
-      expect(assigns[:parse]).to eq(parse)
-    end
-
     it 'renders with pastes layout' do
       paste = create(:paste)
 

--- a/spec/features/user_enters_code_spec.rb
+++ b/spec/features/user_enters_code_spec.rb
@@ -16,6 +16,7 @@ feature 'User visits homepage' do
 
       visit root_path
       fill_in 'Try some code', with: ruby_code
+      select 'Ruby', from: 'parse_language'
 
       expect(page).to have_css('pre.highlight')
       expect(find('span.nb').text).to eq('puts')
@@ -27,6 +28,7 @@ feature 'User visits homepage' do
 
       visit root_path
       fill_in 'Try some code', with: ruby_code
+      select 'Ruby', from: 'parse_language'
 
       expect(find('span.s1').text).to eq("'hello world'")
 


### PR DESCRIPTION
I added a [humans.txt](http://humanstxt.org) file because I saw some requests for it in our logs and I thought it was a nice thing.

Also fixed a couple of tests:

* `controllers/pastes_controller_spec.rb:21`: We used to assign a `@parse` in the pastes controller, but now we parse in side of the paste itself, and we no longer assign that `@parse`.
* `features/user_enters_code_spec.rb`: I as assuming that ruby was always the selected language on the page, but since we added random language examples that is no longer the case. So, now we select ruby as the language explicitly.