### PR TITLE
dynamically fetch rouge versions on a daily basis

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,10 @@ gem 'rack-timeout'
 gem 'rails', '~> 4.2'
 gem 'recipient_interceptor'
 gem 'rollbar'
-gem 'rouge'
+
+# Rouge versions are handled manually. See app/models/rouge_version.rb
+# gem 'rouge'
+
 gem 'sass-rails'
 gem 'simple_form'
 gem 'title'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -202,7 +202,6 @@ GEM
       mail
     rollbar (2.11.5)
       multi_json
-    rouge (2.1.0)
     rspec (3.4.0)
       rspec-core (~> 3.4.0)
       rspec-expectations (~> 3.4.0)
@@ -305,7 +304,6 @@ DEPENDENCIES
   rails (~> 4.2)
   recipient_interceptor
   rollbar
-  rouge
   rspec-rails
   sass-rails
   shoulda-matchers

--- a/Rakefile
+++ b/Rakefile
@@ -16,3 +16,5 @@ if defined? RSpec
 end
 
 task default: 'bundler:audit'
+
+task daily: 'rouge:precache'

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
+  around_filter :detect_rouge_version
 
   [Highlighter::LexerNotFound,
    Highlighter::FormatterNotFound].each do |highlighter_error|
@@ -9,5 +10,18 @@ class ApplicationController < ActionController::Base
       @parse = "<span class='err'>Error: #{exception.message}</span>".html_safe
       render 'parses/create'
     end
+  end
+
+  def detect_rouge_version
+    version = params[:rouge_version]&.strip
+    return yield unless version
+    return yield unless version =~ /\A\d+[.]\d+[.]\d+\z/
+    return yield unless RougeVersion.version(params[:rouge_version])
+
+    RougeVersion.with_version(params[:rouge_version]) { yield }
+  end
+
+  def rouge
+    RougeVersion.current
   end
 end

--- a/app/controllers/home_pages_controller.rb
+++ b/app/controllers/home_pages_controller.rb
@@ -1,6 +1,6 @@
 class HomePagesController < ApplicationController
   def show
-    lexer = Rouge::Lexer.all.sample
+    lexer = rouge::Lexer.all.sample
     @demo = Paste.demo_for(lexer)
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,10 @@
 module ApplicationHelper
+  def rouge
+    RougeVersion.current
+  end
+
   def all_lexers
-    Rouge::Lexer.all.sort_by(&:tag)
+    rouge::Lexer.all.sort_by(&:tag)
   end
 
   def lexer_options_for_select

--- a/app/models/paste.rb
+++ b/app/models/paste.rb
@@ -7,7 +7,7 @@ class Paste < ActiveRecord::Base
   end
 
   def lexer
-    Rouge::Lexer.find(self.language)
+    RougeVersion.current::Lexer.find(self.language)
   end
 
   def parse

--- a/app/models/rouge_version.rb
+++ b/app/models/rouge_version.rb
@@ -1,0 +1,75 @@
+module RougeVersion
+  class << self
+    TMP_DIR = Pathname.new(ENV['ROUGE_VERSION_TMP'] || Rails.root.join('tmp/rouge-versions'))
+    Bundler.mkdir_p(TMP_DIR)
+
+    def available_versions_file
+      TMP_DIR.join('available_versions')
+    end
+
+    def fetch_available_versions
+      response = `gem query --versions --all -r -e rouge`
+
+      response =~ /rouge\s*[(](.*?)[)]/
+
+      return nil unless $1
+
+      versions = $1.split(/,\s*/).reverse
+
+      available_versions_file.open('w') { |f| f.puts versions }
+
+      versions
+    end
+
+    def available_versions
+      if available_versions_file.exist? and Time.now - available_versions_file.mtime <= 1.day
+        return available_versions_file.readlines.map(&:chomp)
+      end
+
+      fetch_available_versions
+    end
+
+    def versions_cache
+      @versions_cache ||= {}
+    end
+
+    def version(version_number)
+      versions_cache[version_number] ||= load_version(version_number)
+    end
+
+    def with_version(version_number)
+      t = Thread.current
+      k = :'RougeVersion.current'
+
+      t[k], old = version_number, t[k]
+      yield
+    ensure
+      t[k] = old
+    end
+
+    def current
+      version(Thread.current[:'RougeVersion.current'] || available_versions.last)
+    end
+
+    def load_version(version_number)
+      version_dir = TMP_DIR.join("rouge-#{version_number}")
+      fetch_version(version_number) unless version_dir.exist?
+
+      # clean up just in case
+      Object.send(:remove_const, :Rouge) rescue NameError
+
+      Kernel.load(version_dir.join('lib/rouge.rb'))
+      rouge = Rouge
+      Object.send(:remove_const, :Rouge)
+
+      rouge
+    end
+
+    def fetch_version(version_number)
+      Dir.chdir(TMP_DIR) do
+        system "gem fetch rouge -v #{version_number}"
+        system "gem unpack rouge-#{version_number}.gem"
+      end
+    end
+  end
+end

--- a/app/service/highlighter.rb
+++ b/app/service/highlighter.rb
@@ -3,8 +3,7 @@ class Highlighter
   class LexerNotFound < StandardError; end
 
   def initialize(params)
-    opts = { format: 'html' }
-    @params = opts.merge(params.symbolize_keys)
+    @params = params.with_indifferent_access
   end
 
   def self.perform(params)
@@ -21,8 +20,12 @@ class Highlighter
     @source ||= @params[:source].encode(universal_newline: true)
   end
 
+  def rouge
+    RougeVersion.current
+  end
+
   def lexer
-    if @lexer ||= Rouge::Lexer.find(@params[:language])
+    if @lexer ||= rouge::Lexer.find(@params[:language])
       @lexer
     else
       raise LexerNotFound, I18n.t('errors.highlighter.lexer_not_found')
@@ -30,10 +33,6 @@ class Highlighter
   end
 
   def formatter
-    if @formatter ||= Rouge::Formatter.find(@params[:format])
-      @formatter.new(wrap: false)
-    else
-      raise FormatterNotFound, I18n.t('errors.highlighter.formatter_not_found')
-    end
+    @formatter ||= rouge::Formatters::HTML.new(wrap: false)
   end
 end

--- a/app/views/application/_footer.html.erb
+++ b/app/views/application/_footer.html.erb
@@ -1,4 +1,5 @@
 <footer>
   Rouge development by <%= link_to 'Jeanine Adkisson', 'http://jneen.net', target: '_blank' %>.
   Website created by <%= link_to 'Edward Loveall', 'http://edwardloveall.com', target: '_blank' %>.
+  Using Rouge version <%= RougeVersion.current.version %>
 </footer>

--- a/lib/tasks/rouge.rake
+++ b/lib/tasks/rouge.rake
@@ -1,0 +1,26 @@
+namespace :rouge do
+  task :precache => :precache_available do
+    require "#{Rails.root}/app/models/rouge_version.rb"
+
+    RougeVersion.fetch_available_versions.each do |version|
+      # no prerelease versions
+      next if version =~ /^0[.]/
+
+      # fetches if not already on disk
+      puts "fetching #{version}..."
+      begin
+        RougeVersion.load_version(version)
+      rescue LoadError => e
+        puts e.to_s
+      end
+
+      puts "done"
+    end
+  end
+
+  task :precache_available do
+    require "#{Rails.root}/app/models/rouge_version.rb"
+
+    RougeVersion.fetch_available_versions
+  end
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,9 +1,11 @@
 require 'rails_helper'
 
 describe ApplicationHelper do
+  let(:rouge) { RougeVersion.current }
+
   describe '#lexer_options_for_select' do
     it 'returns a hash of languages and values' do
-      cpp = Rouge::Lexer.find('cpp')
+      cpp = rouge::Lexer.find('cpp')
       option = [cpp.title, cpp.tag]
 
       lexer_options = helper.lexer_options_for_select
@@ -15,7 +17,7 @@ describe ApplicationHelper do
 
   describe '#lexer_count' do
     it 'returns the count of languages available to parse' do
-      count = Rouge::Lexer.all.count
+      count = rouge::Lexer.all.count
 
       expect(helper.lexer_count).not_to eq(0)
       expect(helper.lexer_count).to eq(count)


### PR DESCRIPTION
On this branch, if you provide `?rouge_version=...` in any URL parameter, that version of rouge will be used across the site.

This looks hacky, but hear me out! This PR removes rouge from the Gemfile, and manually manages it. Since rouge has no dependencies, and uses `load` and never caches any global state, we can safely load mutliple versions into the runtime, using `Object.send(:const_remove, :Rouge)`.

In the future, perhaps @edwardloveall could add a dropdown or autocomplete menu to select a version. But even as it stands, this means that the site will always use the latest rouge version by default, within a day of release.

cc @gfx @dblessing