### PR TITLE
fix some of the issues that came up from #30

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -9,8 +9,12 @@ module ApplicationHelper
 
   def lexer_options_for_select
     all_lexers.map do |lexer|
-      [lexer.title, lexer.tag]
+      [lexer_title(lexer), lexer.tag]
     end
+  end
+
+  def lexer_title(lexer)
+    lexer.respond_to?(:title) ? lexer.title : lexer.tag
   end
 
   def lexer_count

--- a/app/models/paste.rb
+++ b/app/models/paste.rb
@@ -7,7 +7,11 @@ class Paste < ActiveRecord::Base
   end
 
   def lexer
-    RougeVersion.current::Lexer.find(self.language)
+    @lexer ||= RougeVersion.current::Lexer.find(self.language)
+  end
+
+  def lexer_title
+    lexer.respond_to?(:title) ? lexer.title : lexer.tag
   end
 
   def parse

--- a/app/views/pastes/show.html.erb
+++ b/app/views/pastes/show.html.erb
@@ -1,7 +1,7 @@
 <section class="paste">
   <aside class="meta">
     <span class="date"><%= l(@paste.created_at, format: :simple) -%></span>
-    <span class="language"><%= @paste.lexer.title -%></span>
+    <span class="language"><%= lexer_title(@paste) -%></span>
   </aside>
   <pre class="highlight"><code><%= @paste.parse %></code></pre>
 </section>


### PR DESCRIPTION
Turns out @edwardloveall was right about a few things:

* `Lexer#title` is not available in old Rouge versions
* We *definitely* need to load using a mutex, since we're messing with global state
* There is a case where Rouge tries to lazily load some files, and we need to eagerly load them so that they get loaded when the global constant `Rouge` is available and correct (this is the cause of the SystemStackError in Rollbar).